### PR TITLE
feat: add flake-based system config

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,29 +1,13 @@
-{ config, lib, pkgs, ... }:
-
-let
-  pinnedPkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/25.05.tar.gz";
-    sha256 = "1915r28xc4znrh2vf4rrjnxldw2imysz819gzhk9qlrkqanmfsxd";
-  }) { config = { allowUnfree = true; }; };
-
-  hmTarball = builtins.fetchTarball {
-    url = "https://github.com/nix-community/home-manager/archive/refs/heads/release-25.05.tar.gz";
-    sha256 = "sha256-oV695RvbAE4+R9pcsT9shmp6zE/+IZe6evHWX63f2Qg=";
-  };
-in
+{ config, pkgs, ... }:
 {
+  nixpkgs.config.allowUnfree = true;
   nix = {
     package = pkgs.nix;
-    settings = {
-      experimental-features = [ "nix-command" "flakes" ];
-    };
+    settings.experimental-features = [ "nix-command" "flakes" ];
   };
-
-  nixpkgs.pkgs = pinnedPkgs;
 
   imports = [
     ./hardware-configuration.nix
-    (import "${hmTarball}/nixos")
     ./modules/base.nix
     ./modules/users/young.nix
     ./modules/desktop/gnome.nix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753592768,
+        "narHash": "sha256-oV695RvbAE4+R9pcsT9shmp6zE/+IZe6evHWX63f2Qg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "fc3add429f21450359369af74c2375cb34a2d204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754028485,
+        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "NixOS configuration for n7-z790";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    home-manager.url = "github:nix-community/home-manager/release-25.05";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, home-manager, ... }:
+    let
+      system = "x86_64-linux";
+    in {
+      nixosConfigurations.n7-z790 = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./configuration.nix
+          home-manager.nixosModules.home-manager
+        ];
+      };
+    };
+}

--- a/hardware-configuration.nix
+++ b/hardware-configuration.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, ... }:
+{
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  swapDevices = [ ];
+}

--- a/home/young/home.nix
+++ b/home/young/home.nix
@@ -1,7 +1,5 @@
 { config, pkgs, ... }:
 {
-  programs.dconf.enable = true;
-
   dconf.settings = {
     "org/gnome/desktop/remote-desktop" = {
       # 二擇一或都開

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -4,7 +4,7 @@
   boot.loader.efi.canTouchEfiVariables = true;
   boot.kernelPackages = pkgs.linuxPackages_latest;
 
-  networking.hostName = "nixos";
+  networking.hostName = "n7-z790";
   networking.networkmanager.enable = true;
 
   time.timeZone = "Asia/Taipei";

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -6,6 +6,7 @@
 
     users.young = {
       home.stateVersion = "25.05";
+      imports = [ ../home/young/home.nix ];
 
       programs.git = {
         enable = true;


### PR DESCRIPTION
## Summary
- convert NixOS setup to flake with home-manager
- set hostname to n7-z790 and enable unfree packages
- include user home config and minimal hardware stub

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake update`
- `nix --extra-experimental-features 'nix-command flakes' flake check`

------
https://chatgpt.com/codex/tasks/task_e_6890cd082da88327bd6fa0d0feefc88c