### PR TITLE
Enable fcitx5 Zhuyin input method

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -16,7 +16,7 @@
     nix-output-monitor
 
     # Fonts and input methods
-    fcitx5 fcitx5-configtool fcitx5-chewing fcitx5-gtk fcitx5-qt jetbrains-mono
+    fcitx5 fcitx5-configtool fcitx5-chewing fcitx5-gtk libsForQt5.fcitx5-qt jetbrains-mono
 
     # multimedia tools
     yt-dlp cava

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -16,7 +16,7 @@
     nix-output-monitor
 
     # Fonts and input methods
-    ibus jetbrains-mono
+    fcitx5 fcitx5-configtool fcitx5-chewing jetbrains-mono
 
     # multimedia tools
     yt-dlp cava

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -16,7 +16,7 @@
     nix-output-monitor
 
     # Fonts and input methods
-    fcitx5 fcitx5-configtool fcitx5-chewing jetbrains-mono
+    fcitx5 fcitx5-configtool fcitx5-chewing fcitx5-gtk fcitx5-qt jetbrains-mono
 
     # multimedia tools
     yt-dlp cava

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -26,20 +26,21 @@
     enable = true;
     type = "fcitx5";
     fcitx5.addons = with pkgs; [ fcitx5-chewing ];
-    fcitx5.profile = ''
-      [Profile]
-      ConfigVersion=1
-
-      [Groups/0]
-      Name=Default
-      Default Layout=us
-      DefaultIM=chewing
-
-      [Groups/0/Items/0]
-      Name=chewing
-      Layout=us
-    '';
   };
+
+  environment.etc."xdg/fcitx5/profile".text = ''
+    [Profile]
+    ConfigVersion=1
+
+    [Groups/0]
+    Name=Default
+    Default Layout=us
+    DefaultIM=chewing
+
+    [Groups/0/Items/0]
+    Name=chewing
+    Layout=us
+  '';
 
   services.openssh.enable = true;
   services.printing.enable = true;

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -22,6 +22,11 @@
     LC_TIME = "zh_TW.UTF-8";
   };
 
+  i18n.inputMethod = {
+    enabled = "fcitx5";
+    fcitx5.addons = with pkgs; [ fcitx5-chewing ];
+  };
+
   services.openssh.enable = true;
   services.printing.enable = true;
 

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -25,6 +25,23 @@
   i18n.inputMethod = {
     enabled = "fcitx5";
     fcitx5.addons = with pkgs; [ fcitx5-chewing ];
+    fcitx5.settings = {
+      inputMethod = {
+        "GroupOrder" = { "0" = "Default"; };
+        "Groups/0" = {
+          "Name" = "Default";
+          "Default Layout" = "us";
+          "DefaultIM" = "chewing";
+        };
+        "Groups/0/Items/0" = {
+          "Name" = "keyboard-us";
+        };
+        "Groups/0/Items/1" = {
+          "Name" = "chewing";
+          "Layout" = "us";
+        };
+      };
+    };
   };
 
   services.openssh.enable = true;

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -26,23 +26,19 @@
     enable = true;
     type = "fcitx5";
     fcitx5.addons = with pkgs; [ fcitx5-chewing ];
-    fcitx5.settings = {
-      inputMethod = {
-        "GroupOrder" = { "0" = "Default"; };
-        "Groups/0" = {
-          "Name" = "Default";
-          "Default Layout" = "us";
-          "DefaultIM" = "chewing";
-        };
-        "Groups/0/Items/0" = {
-          "Name" = "keyboard-us";
-        };
-        "Groups/0/Items/1" = {
-          "Name" = "chewing";
-          "Layout" = "us";
-        };
-      };
-    };
+    fcitx5.profile = ''
+      [Profile]
+      ConfigVersion=1
+
+      [Groups/0]
+      Name=Default
+      Default Layout=us
+      DefaultIM=chewing
+
+      [Groups/0/Items/0]
+      Name=chewing
+      Layout=us
+    '';
   };
 
   services.openssh.enable = true;

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -23,7 +23,8 @@
   };
 
   i18n.inputMethod = {
-    enabled = "fcitx5";
+    enable = true;
+    type = "fcitx5";
     fcitx5.addons = with pkgs; [ fcitx5-chewing ];
     fcitx5.settings = {
       inputMethod = {


### PR DESCRIPTION
## Summary
- switch to fcitx5 with Zhuyin (Chewing) input method
- replace ibus packages with fcitx5

## Testing
- `nix flake check` *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_68975a6077b483278733ba2d0065d369